### PR TITLE
Rename containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ You can find the latest version of Saleor, storefront and dashboard in their ind
 
 
 ## Where is the application running?
-- Saleor backend (API) - http://localhost:8000
-- Saleor storefront - http://localhost:3000
-- Saleor dashboard - http://localhost:9000
-- Jaeger UI (OpenTracing) - http://localhost:16686
+- Saleor Core (API) - http://localhost:8000
+- Saleor Storefront - http://localhost:3000
+- Saleor Dashboard - http://localhost:9000
+- Jaeger UI (APM) - http://localhost:16686
 
 
 If you have any questions or feedback, do not hesitate to contact us via Spectrum or Gitter:

--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ $ docker-compose build
 
 5. Apply Django migrations:
 ```
-$ docker-compose run --rm web python3 manage.py migrate
+$ docker-compose run --rm api python3 manage.py migrate
 ```
 
 6. Collect static files:
 ```
-$ docker-compose run --rm web python3 manage.py collectstatic --noinput
+$ docker-compose run --rm api python3 manage.py collectstatic --noinput
 ```
 
 7. Populate the database with example data and create the admin user:
 ```
-$ docker-compose run --rm web python3 manage.py populatedb --createsuperuser
+$ docker-compose run --rm api python3 manage.py populatedb --createsuperuser
 ```
 *Note that `--createsuperuser` argument creates an admin account for `admin@example.com` with the password set to `admin`.*
 
@@ -70,12 +70,12 @@ You can find the latest version of Saleor, storefront and dashboard in their ind
 
 
 ## How to run application parts?
-  - `docker-compose up web celery` for backend services only
+  - `docker-compose up api worker` for backend services only
   - `docker-compose up` for backend and frontend services
 
 
 ## Where is the application running?
-- Saleor backend - http://localhost:8000
+- Saleor backend (API) - http://localhost:8000
 - Saleor storefront - http://localhost:3000
 - Saleor dashboard - http://localhost:9000
 - Jaeger UI (OpenTracing) - http://localhost:16686

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       # prevents overshadowing of build-time assets
       - /app/saleor/static/assets
       - /app/templates/templated_email/compiled
-      # shared volume between celery and api for media
+      # shared volume between worker and api for media
       - saleor-media:/app/media
     command: python manage.py runserver 0.0.0.0:8000
     env_file: ./saleor/common.env
@@ -77,7 +77,7 @@ services:
     volumes:
       - saleor-redis:/data
 
-  celery:
+  worker:
     build:
       context: ./saleor
       dockerfile: ./Dockerfile
@@ -95,7 +95,7 @@ services:
       - ./saleor/templates/:/app/templates:Z,cached
       # prevents overshadowing of build-time assets
       - /app/templates/templated_email/compiled
-      # shared volume between celery and api for media
+      # shared volume between worker and api for media
       - saleor-media:/app/media
 
   jaeger:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 
 services:
-  web:
+  api:
     ports:
       - 8000:8000
     build:
@@ -23,7 +23,7 @@ services:
       # prevents overshadowing of build-time assets
       - /app/saleor/static/assets
       - /app/templates/templated_email/compiled
-      # shared volume between celery and web for media
+      # shared volume between celery and api for media
       - saleor-media:/app/media
     command: python manage.py runserver 0.0.0.0:8000
     env_file: ./saleor/common.env
@@ -95,7 +95,7 @@ services:
       - ./saleor/templates/:/app/templates:Z,cached
       # prevents overshadowing of build-time assets
       - /app/templates/templated_email/compiled
-      # shared volume between celery and web for media
+      # shared volume between celery and api for media
       - saleor-media:/app/media
 
   jaeger:


### PR DESCRIPTION
Since `./saleor` contains api only, naming it `web` is no longer valid.
Also, using name 'celery' can be confusing outside of Django world.