### PR TITLE
Add storefront and dashboard urls envs to api service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     env_file: ./saleor/common.env
     environment:
       - JAEGER_AGENT_HOST=jaeger
+      - STOREFRONT_URL=http://localhost:3000/
+      - DASHBOARD_URL=http://localhost:9000/
 
   storefront:
     build:


### PR DESCRIPTION
Add storefront_url and dashboard_url to api service. It will be needed for the splash page to work.
Context: https://github.com/mirumee/saleor/pull/5494