### PR TITLE
Move common.env file from saleor to platform

### DIFF
--- a/common.env
+++ b/common.env
@@ -1,0 +1,4 @@
+DATABASE_URL=postgres://saleor:saleor@db/saleor
+DEFAULT_FROM_EMAIL=noreply@example.com
+CELERY_BROKER_URL=redis://redis:6379/1
+SECRET_KEY=changeme

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       # shared volume between worker and api for media
       - saleor-media:/app/media
     command: python manage.py runserver 0.0.0.0:8000
-    env_file: ./saleor/common.env
+    env_file: common.env
     environment:
       - JAEGER_AGENT_HOST=jaeger
       - STOREFRONT_URL=http://localhost:3000/
@@ -89,7 +89,7 @@ services:
     restart: unless-stopped
     networks:
       - saleor-backend-tier
-    env_file: ./saleor/common.env
+    env_file: common.env
     depends_on:
       - redis
     volumes:


### PR DESCRIPTION
Moves the `common.env` file from `saleor` repo. It's no longer useful in `saleor` since we don't have the docker-compose file there.