### PR TITLE
update celery run command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       dockerfile: ./Dockerfile
       args:
         STATIC_URL: '/static/'
-    command: celery -A saleor worker --app=saleor.celeryconf:app --loglevel=info
+    command: celery --app saleor.celeryconf:app -A saleor worker 
     restart: unless-stopped
     networks:
       - saleor-backend-tier


### PR DESCRIPTION
The old command has deprecated syntax.
https://docs.celeryproject.org/en/latest/whatsnew-5.0.html#step-1-adjust-your-command-line-invocation