### PR TITLE
update celery worker command in docker-compose.yml for celery 5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       dockerfile: ./Dockerfile
       args:
         STATIC_URL: '/static/'
-    command: celery -A saleor worker --app=saleor.celeryconf:app --loglevel=info
+    command: celery -A saleor --app=saleor.celeryconf:app worker --loglevel=info
     restart: unless-stopped
     networks:
       - saleor-backend-tier


### PR DESCRIPTION
Upon running `docker-compose up`, I got an error that as of Celery v5 the `--app` option must be a global opt, not passed to `worker`. After making this change, the worker ran again.