### PR TITLE
Add new env var DEVMODE

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       dockerfile: ./Dockerfile
       args:
         STATIC_URL: '/static/'
+        DEVMODE: 'on'
     restart: unless-stopped
     networks:
       - saleor-backend-tier


### PR DESCRIPTION
I want to merge this because it adds new env var to api called `DEVMODE`.
According PR will be merged inside saleor to make it work.
Why?
In dockerfile we want to call
`poetry install --no-root --no-dev` in case of prod
`poetry install --no-root` in case of development
So that mentioned variable forces expected behavior.