### PR TITLE
Fix env variable for email plugin configuration

### DIFF
--- a/common.env
+++ b/common.env
@@ -2,3 +2,4 @@ DATABASE_URL=postgres://saleor:saleor@db/saleor
 DEFAULT_FROM_EMAIL=noreply@example.com
 CELERY_BROKER_URL=redis://redis:6379/1
 SECRET_KEY=changeme
+EMAIL_URL=smtp://mailhog:1025

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,8 +95,6 @@ services:
       - ./saleor/templates/:/app/templates:Z,cached
       # shared volume between worker and api for media
       - saleor-media:/app/media
-    environment:
-      - EMAIL_URL=smtp://mailhog:1025
 
   jaeger:
     image: jaegertracing/all-in-one


### PR DESCRIPTION
Currently, after someone runs migrations, the email plugin wouldn't work. Ower migration gets `EMAIL_URL` from env and use it in the email plugin configuration. We should have set `EMAIL_URL` in `api` container. 