### PR TITLE
Fix storefront not loading

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     volumes:
       - ./saleor-storefront/:/app:cached
       - /app/node_modules/
-    command: npm start -- --hostname 0.0.0.0
+    command: npm start -- --host 0.0.0.0 # --hostname shouldn't be used, as far as tested
 
   dashboard:
     build:


### PR DESCRIPTION
Replace `--hostname` with `--host` to fix the storefront launch problem.

References:

https://github.com/mirumee/saleor-platform/issues/95#issuecomment-841470151

https://github.com/mirumee/saleor-platform/issues/97#issuecomment-841634921
