### PR TITLE
docker-compose.yml fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     volumes:
       - ./saleor-storefront/:/app:cached
       - /app/node_modules/
-    command: npm start -- --hostname 0.0.0.0
+    command: npm start -- --host 0.0.0.0
 
   dashboard:
     build:


### PR DESCRIPTION
docker-compose.yml has wrong parameter for webpack-dev-server in the storefront container, which makes the frontend inaccessible on the host machine on linux.

"--hostname" should be "--host"