### PR TITLE
Fix connection error when running dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     volumes:
       - ./saleor-storefront/:/app:cached
       - /app/node_modules/
-    command: npm start -- --hostname 0.0.0.0
+    command: npm start -- --host 0.0.0.0
 
   dashboard:
     build:


### PR DESCRIPTION
Prior to this change whenever you started the docker-compose
you get Connection Error from store-front service since there was an error
in the param --host leading the webpack dev server to only open port for
the loopback interface of the container.

Closes #106 